### PR TITLE
Fix building failure on Catalina, Conan 1.21.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -78,7 +78,7 @@ class CAFConan(ConanFile):
         cmake.definitions["CAF_BUILD_STATIC"] = self._is_static
         cmake.definitions["CAF_BUILD_STATIC_ONLY"] = self._is_static
         cmake.definitions["CAF_LOG_LEVEL"] = self.default_options['log_level'].index(self.options.log_level.value)
-        cmake.configure(build_dir=self._build_subfolder)
+        cmake.configure(build_folder=self._build_subfolder)
         return cmake
 
     def build(self):


### PR DESCRIPTION
I failed to get this recipe build on macOS Catalina (with clang 11.0.0, conan 1.21.0)

I then check the official doc of conan [here](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#configure), and found:

> build_dir (Optional, Defaulted to None): [DEPRECATED] Use build_folder instead. CMake’s output directory. The default value is the package build root folder if None is specified. The CMake object will store build_folder internally for subsequent calls to build().

Issue get solved after changed `build_dir` to `build_folder`, even I don't actually understand why.